### PR TITLE
Add assert for tmpdir and tmpdir/FCIDUMP_chol

### DIFF
--- a/ad_afqmc/launch_script.py
+++ b/ad_afqmc/launch_script.py
@@ -2,7 +2,7 @@ import argparse
 import pickle
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
-
+import os
 import h5py
 import numpy as np
 from jax import numpy as jnp
@@ -63,6 +63,7 @@ def read_fcidump(tmp_dir: Optional[str] = None) -> Tuple:
     """
     directory = tmp_dir if tmp_dir is not None else tmpdir
 
+    assert os.path.isfile(directory + "/FCIDUMP_chol"), f"File '{directory}/FCIDUMP_chol' does not exist."
     with h5py.File(directory + "/FCIDUMP_chol", "r") as fh5:
         [nelec, norb, ms, nchol] = fh5["header"]
         h0 = jnp.array(fh5.get("energy_core"))

--- a/ad_afqmc/run_afqmc.py
+++ b/ad_afqmc/run_afqmc.py
@@ -35,8 +35,11 @@ def run_afqmc(
         try:
             with open("tmpdir.txt", "r") as f:
                 tmpdir = f.read().strip()
+            print(f"# tmpdir.txt file found: tmpdir is set to '{tmpdir}'\n#")
         except:
             tmpdir = "."
+    assert os.path.isdir(tmpdir), f"tmpdir directory '{tmpdir}' does not exist."
+
     if options is not None:
         with open(tmpdir + "/options.bin", "wb") as f:
             pickle.dump(options, f)


### PR DESCRIPTION
Asserting that the directory tmpdir exists should solve some issues.
Asserting that FCIDUMP_chol exists avoid long and ugly error messages.