### PR TITLE
Preparation routine for multislater trials (restricted, unrestricted)

### DIFF
--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -145,9 +145,9 @@ def getCollocationMatrices(
 
     coords = grids.coords
     weights = grids.weights
-    ao = mol.eval_gto("GTOval_sph", coords)  #aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  #mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  #mos on coords
+    ao = mol.eval_gto("GTOval_sph", coords)  ##aos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  ##mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  ##mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]

--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -101,7 +101,8 @@ def prep_afqmc(
     chol = chol.reshape((chol.shape[0], -1))
 
     # write trial mo coefficients
-    trial_coeffs = write_trial(mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
+    trial_coeffs = write_trial(
+        mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
 
     write_dqmc(
         h1e,
@@ -145,9 +146,11 @@ def getCollocationMatrices(
 
     coords = grids.coords
     weights = grids.weights
-    ao = mol.eval_gto("GTOval_sph", coords)  ##aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights) ** alpha)  ##mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights) ** alpha)  ##mos on coords
+    ao = mol.eval_gto("GTOval_sph", coords)  # aos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)
+                   ** alpha)  # mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)
+                   ** alpha)  # mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]
@@ -216,12 +219,13 @@ def solveLS_twoSided(T, X1, X2):
     X12 = jnp.einsum("Pa,Pb->abP", X1, X2)
     E = jnp.einsum("abP, abcd->Pcd", X12, T).reshape(X1.shape[0], -1)
 
-    E = scipy.linalg.cho_solve((L, True), E).reshape(-1, T.shape[2], T.shape[3])
+    E = scipy.linalg.cho_solve(
+        (L, True), E).reshape(-1, T.shape[2], T.shape[3])
 
     E = jnp.einsum("Pcd, cdQ->PQ", E, X12).T
     V = scipy.linalg.cho_solve((L, True), E)
 
-    ##symmetrize it
+    # symmetrize it
     V = 0.5 * (V + V.T)
 
     return V
@@ -328,7 +332,8 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         shls = (i, i + 1, 0, mol.nbas, i, i + 1, 0, mol.nbas)
         buf = mol.intor("int2e_sph", shls_slice=shls)
         di, dk, dj, dl = buf.shape
-        diag[ndiag : ndiag + di * nao] = buf.reshape(di * nao, di * nao).diagonal()
+        diag[ndiag: ndiag + di *
+             nao] = buf.reshape(di * nao, di * nao).diagonal()
         ndiag += di * nao
     nu = np.argmax(diag)
     delta_max = diag[nu]
@@ -350,7 +355,8 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         "int2e_sph", shls_slice=(0, mol.nbas, 0, mol.nbas, sj, sj + 1, sl, sl + 1)
     )
     cj, cl = max(j - dims[sj], 0), max(l - dims[sl], 0)
-    chol_vecs[0] = np.copy(eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
+    chol_vecs[0] = np.copy(
+        eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
 
     nchol = 0
     while abs(delta_max) > max_error:
@@ -638,7 +644,8 @@ def get_excitations(
             Acre[nex], Ades[nex] = Acre.get(nex, []) + [occ_idx_a_rel], Ades.get(
                 nex, []
             ) + [np.nonzero((d0a - dia) < 0)]
-            coeff[nex][-1] *= parity(d0a, np.nonzero((d0a - dia) > 0), Ades[nex][-1])
+            coeff[nex][-1] *= parity(d0a,
+                                     np.nonzero((d0a - dia) > 0), Ades[nex][-1])
 
         elif nex[0] == 0 and nex[1] > 0:
             occ_idx_b_rel = (
@@ -649,7 +656,8 @@ def get_excitations(
             Bcre[nex], Bdes[nex] = Bcre.get(nex, []) + [occ_idx_b_rel], Bdes.get(
                 nex, []
             ) + [np.nonzero((d0b - dib) < 0)]
-            coeff[nex][-1] *= parity(d0b, np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
+            coeff[nex][-1] *= parity(d0b,
+                                     np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
 
     coeff[(0, 0)] = np.asarray(coeff[(0, 0)]).reshape(
         -1,
@@ -685,10 +693,14 @@ def get_excitations(
         if i != 0:
             for j in range(1, max_excitation + 1 - i):
                 if (i, j) in Ades:
-                    Ades[(i, j)] = np.asarray(Ades[(i, j)]).reshape(-1, i) + num_core
-                    Acre[(i, j)] = np.asarray(Acre[(i, j)]).reshape(-1, i) + num_core
-                    Bdes[(i, j)] = np.asarray(Bdes[(i, j)]).reshape(-1, j) + num_core
-                    Bcre[(i, j)] = np.asarray(Bcre[(i, j)]).reshape(-1, j) + num_core
+                    Ades[(i, j)] = np.asarray(
+                        Ades[(i, j)]).reshape(-1, i) + num_core
+                    Acre[(i, j)] = np.asarray(
+                        Acre[(i, j)]).reshape(-1, i) + num_core
+                    Bdes[(i, j)] = np.asarray(
+                        Bdes[(i, j)]).reshape(-1, j) + num_core
+                    Bcre[(i, j)] = np.asarray(
+                        Bcre[(i, j)]).reshape(-1, j) + num_core
                     coeff[(i, j)] = np.asarray(coeff[(i, j)]).reshape(
                         -1,
                     )
@@ -808,7 +820,7 @@ def parity(d0: np.ndarray, cre: Sequence, des: Sequence) -> float:
     D = np.asarray(des).flatten()
     for i in range(C.shape[0]):
         I, A = min(D[i], C[i]), max(D[i], C[i])
-        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1 : A])) % 2)
+        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1: A])) % 2)
         d[C[i]] = 0
         d[D[i]] = 1
     return float(parity)
@@ -845,7 +857,8 @@ def read_pyscf_ccsd(mf_or_cc, tmpdir):
             ci2bb=ci2bb,
         )
     else:
-        ci2 = cc.t2 + np.einsum("ia,jb->ijab", np.array(cc.t1), np.array(cc.t1))
+        ci2 = cc.t2 + np.einsum("ia,jb->ijab",
+                                np.array(cc.t1), np.array(cc.t1))
         ci2 = ci2.transpose(0, 2, 1, 3)
         ci1 = np.array(cc.t1)
         np.savez(tmpdir + "/amplitudes.npz", ci1=ci1, ci2=ci2)
@@ -902,7 +915,8 @@ def compute_cholesky_integrals(mol, mf, basis_coeff, integrals, norb_frozen, cho
             mc.mo_coeff = basis_coeff  # type: ignore
             h1e, enuc = mc.get_h1eff()  # type: ignore
             chol = chol.reshape((-1, nbasis, nbasis))
-            chol = chol[:, mc.ncore : mc.ncore + mc.ncas, mc.ncore : mc.ncore + mc.ncas]  # type: ignore
+            chol = chol[:, mc.ncore: mc.ncore + mc.ncas,
+                        mc.ncore: mc.ncore + mc.ncas]  # type: ignore
     return h1e, chol, nelec, enuc, nbasis, nchol
 
 
@@ -910,39 +924,29 @@ def write_trial(mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir):
     assert basis_coeff.dtype == "float", "Only implemented for real-valued MOs"
     trial_coeffs = np.empty((2, nbasis, nbasis))
     overlap = mf.get_ovlp(mol)
-    if isinstance(mf, (scf.uhf.UHF, scf.rohf.ROHF)):
-        uhfCoeffs = np.empty((nbasis, 2 * nbasis))
-        if isinstance(mf, scf.uhf.UHF):
-            uhfCoeffs = construct_uhf_coeffs_from_uhf(mf.mo_coeff, overlap, norb_frozen, nbasis)
-        else:
-            uhfCoeffs = construct_uhf_coeffs_from_rhf(mf.mo_coeff, overlap, norb_frozen, nbasis)
+    if isinstance(mf, (scf.rohf.ROHF, scf.rhf.RHF)):
+        uhfCoeffs = construct_uhf_coeffs_from_rhf(
+            basis_coeff, mf.mo_coeff, overlap, norb_frozen, nbasis)
+    elif isinstance(mf, scf.uhf.UHF):
+        uhfCoeffs = construct_uhf_coeffs_from_uhf(
+            basis_coeff, mf.mo_coeff, overlap, norb_frozen, nbasis)
+    else:
+        print("Cannot recognize type for mf object in write_trial")
+        exit(1)
 
-        trial_coeffs[0] = uhfCoeffs[:, :nbasis]
-        trial_coeffs[1] = uhfCoeffs[:, nbasis:]
-        # np.savetxt("uhf.txt", uhfCoeffs)
-        np.savez(tmpdir + "/mo_coeff.npz", mo_coeff=trial_coeffs)
+    trial_coeffs[0] = uhfCoeffs[:, :nbasis]
+    trial_coeffs[1] = uhfCoeffs[:, nbasis:]
 
-    elif isinstance(mf, scf.rhf.RHF):
-        uhfCoeffs = construct_uhf_coeffs_from_rhf(mf.mo_coeff, overlap, norb_frozen, nbasis)
-        trial_coeffs[0] = uhfCoeffs[:,:nbasis]
-        trial_coeffs[1] = uhfCoeffs[:,nbasis:]
-        # q, r = np.linalg.qr(
-        #     basis_coeff[:, norb_frozen:]
-        #     .T.dot(overlap)
-        #     .dot(mf.mo_coeff[:, norb_frozen:])
-        # )
-        # sgn = np.sign(r.diagonal())
-        # q = np.einsum("ij,j->ij", q, sgn)
-        # trial_coeffs[0] = q
-        # trial_coeffs[1] = q
-        np.savez(tmpdir + "/mo_coeff.npz", mo_coeff=trial_coeffs)
+    np.savez(tmpdir + "/mo_coeff.npz", mo_coeff=trial_coeffs)
 
     return trial_coeffs
 
 
-def construct_uhf_coeffs_from_uhf(mo_coeff, overlap, norb_frozen, nbasis):
-    # Constructs UHF orbital coefficients relative to the 
-    # alpha basis (mo_coeff[0]) 
+def construct_uhf_coeffs_from_uhf(basis_coeff, mo_coeff, overlap, norb_frozen, nbasis):
+    # Constructs UHF orbital coefficients relative to the
+    # alpha basis (mo_coeff[0])
+    uhfCoeffs = np.empty((nbasis, 2 * nbasis))
+
     q, r = np.linalg.qr(
         basis_coeff[:, norb_frozen:]
         .T.dot(overlap)
@@ -964,9 +968,12 @@ def construct_uhf_coeffs_from_uhf(mo_coeff, overlap, norb_frozen, nbasis):
 
     return uhfCoeffs
 
-def construct_uhf_coeffs_from_rhf(mo_coeff, overlap, norb_frozen, nbasis):
-    # Constructs UHF orbital coefficients (alpha = beta) relative to the 
+
+def construct_uhf_coeffs_from_rhf(basis_coeff, mo_coeff, overlap, norb_frozen, nbasis):
+    # Constructs UHF orbital coefficients (alpha = beta) relative to the
     # restricted basis
+    uhfCoeffs = np.empty((nbasis, 2 * nbasis))
+
     q, r = np.linalg.qr(
         basis_coeff[:, norb_frozen:]
         .T.dot(overlap)
@@ -978,6 +985,7 @@ def construct_uhf_coeffs_from_rhf(mo_coeff, overlap, norb_frozen, nbasis):
     uhfCoeffs[:, nbasis:] = q
 
     return uhfCoeffs
+
 
 def prep_afqmc_ghf_complex(mol, gmf: scf.ghf.GHF, tmpdir, chol_cut=1e-5):
     import scipy.linalg as la
@@ -1084,3 +1092,35 @@ def prep_afqmc_spinor(mol, mo_coeff, h_ao, n_ao, tmpdir, chol_cut=1e-5):
     np.savez(tmpdir + "/mo_coeff.npz", mo_coeff=[q, q])
 
     return h, h_mod, chol
+
+
+def prep_afqmc_multislater(mf, state_dict, max_excitation, ndets, chol_cut=1e-5):
+    Acre, Ades, Bcre, Bdes, coeff, ref_det = get_excitations(
+        state=state_dict, max_excitation=max_excitation, ndets=ndets
+    )  # this function reads the Dice dets.bin file if state is not provided
+
+    prep_afqmc(mf, chol_cut=chol_cut)
+
+    data = np.load("mo_coeff.npz")
+    trial_coeffs = data["mo_coeff"]
+
+    if isinstance(mf, (scf.rhf.RHF, scf.rohf.ROHF)):
+        trial_coeffs = trial_coeffs[0]  # alpha = beta here
+
+    wave_data = {
+        "Acre": Acre,
+        "Ades": Ades,
+        "Bcre": Bcre,
+        "Bdes": Bdes,
+        "coeff": coeff,
+        "ref_det": ref_det,
+        "orbital_rotation": trial_coeffs,
+    }
+
+    import wavefunctions
+    trial = wavefunctions.multislater(
+        mf.mol.nao, mf.mol.nelec, max_excitation=max_excitation)
+
+    import pickle
+    with open("trial.pkl", "wb") as f:
+        pickle.dump([trial, wave_data], f)

--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -101,8 +101,7 @@ def prep_afqmc(
     chol = chol.reshape((chol.shape[0], -1))
 
     # write trial mo coefficients
-    trial_coeffs = write_trial(
-        mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
+    trial_coeffs = write_trial(mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
 
     write_dqmc(
         h1e,
@@ -147,10 +146,8 @@ def getCollocationMatrices(
     coords = grids.coords
     weights = grids.weights
     ao = mol.eval_gto("GTOval_sph", coords)  # aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)
-                   ** alpha)  # mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)
-                   ** alpha)  # mos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  # mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  # mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]
@@ -219,13 +216,12 @@ def solveLS_twoSided(T, X1, X2):
     X12 = jnp.einsum("Pa,Pb->abP", X1, X2)
     E = jnp.einsum("abP, abcd->Pcd", X12, T).reshape(X1.shape[0], -1)
 
-    E = scipy.linalg.cho_solve(
-        (L, True), E).reshape(-1, T.shape[2], T.shape[3])
+    E = scipy.linalg.cho_solve((L, True), E).reshape(-1, T.shape[2], T.shape[3])
 
     E = jnp.einsum("Pcd, cdQ->PQ", E, X12).T
     V = scipy.linalg.cho_solve((L, True), E)
 
-    # symmetrize it
+    #symmetrize it
     V = 0.5 * (V + V.T)
 
     return V
@@ -332,8 +328,7 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         shls = (i, i + 1, 0, mol.nbas, i, i + 1, 0, mol.nbas)
         buf = mol.intor("int2e_sph", shls_slice=shls)
         di, dk, dj, dl = buf.shape
-        diag[ndiag: ndiag + di *
-             nao] = buf.reshape(di * nao, di * nao).diagonal()
+        diag[ndiag: ndiag + di * nao] = buf.reshape(di * nao, di * nao).diagonal()
         ndiag += di * nao
     nu = np.argmax(diag)
     delta_max = diag[nu]
@@ -355,8 +350,7 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         "int2e_sph", shls_slice=(0, mol.nbas, 0, mol.nbas, sj, sj + 1, sl, sl + 1)
     )
     cj, cl = max(j - dims[sj], 0), max(l - dims[sl], 0)
-    chol_vecs[0] = np.copy(
-        eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
+    chol_vecs[0] = np.copy(eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
 
     nchol = 0
     while abs(delta_max) > max_error:
@@ -644,8 +638,7 @@ def get_excitations(
             Acre[nex], Ades[nex] = Acre.get(nex, []) + [occ_idx_a_rel], Ades.get(
                 nex, []
             ) + [np.nonzero((d0a - dia) < 0)]
-            coeff[nex][-1] *= parity(d0a,
-                                     np.nonzero((d0a - dia) > 0), Ades[nex][-1])
+            coeff[nex][-1] *= parity(d0a, np.nonzero((d0a - dia) > 0), Ades[nex][-1])
 
         elif nex[0] == 0 and nex[1] > 0:
             occ_idx_b_rel = (
@@ -656,8 +649,7 @@ def get_excitations(
             Bcre[nex], Bdes[nex] = Bcre.get(nex, []) + [occ_idx_b_rel], Bdes.get(
                 nex, []
             ) + [np.nonzero((d0b - dib) < 0)]
-            coeff[nex][-1] *= parity(d0b,
-                                     np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
+            coeff[nex][-1] *= parity(d0b, np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
 
     coeff[(0, 0)] = np.asarray(coeff[(0, 0)]).reshape(
         -1,
@@ -693,14 +685,10 @@ def get_excitations(
         if i != 0:
             for j in range(1, max_excitation + 1 - i):
                 if (i, j) in Ades:
-                    Ades[(i, j)] = np.asarray(
-                        Ades[(i, j)]).reshape(-1, i) + num_core
-                    Acre[(i, j)] = np.asarray(
-                        Acre[(i, j)]).reshape(-1, i) + num_core
-                    Bdes[(i, j)] = np.asarray(
-                        Bdes[(i, j)]).reshape(-1, j) + num_core
-                    Bcre[(i, j)] = np.asarray(
-                        Bcre[(i, j)]).reshape(-1, j) + num_core
+                    Ades[(i, j)] = np.asarray(Ades[(i, j)]).reshape(-1, i) + num_core
+                    Acre[(i, j)] = np.asarray(Acre[(i, j)]).reshape(-1, i) + num_core
+                    Bdes[(i, j)] = np.asarray(Bdes[(i, j)]).reshape(-1, j) + num_core
+                    Bcre[(i, j)] = np.asarray(Bcre[(i, j)]).reshape(-1, j) + num_core
                     coeff[(i, j)] = np.asarray(coeff[(i, j)]).reshape(
                         -1,
                     )
@@ -820,7 +808,7 @@ def parity(d0: np.ndarray, cre: Sequence, des: Sequence) -> float:
     D = np.asarray(des).flatten()
     for i in range(C.shape[0]):
         I, A = min(D[i], C[i]), max(D[i], C[i])
-        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1: A])) % 2)
+        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1 : A])) % 2)
         d[C[i]] = 0
         d[D[i]] = 1
     return float(parity)
@@ -857,8 +845,7 @@ def read_pyscf_ccsd(mf_or_cc, tmpdir):
             ci2bb=ci2bb,
         )
     else:
-        ci2 = cc.t2 + np.einsum("ia,jb->ijab",
-                                np.array(cc.t1), np.array(cc.t1))
+        ci2 = cc.t2 + np.einsum("ia,jb->ijab", np.array(cc.t1), np.array(cc.t1))
         ci2 = ci2.transpose(0, 2, 1, 3)
         ci1 = np.array(cc.t1)
         np.savez(tmpdir + "/amplitudes.npz", ci1=ci1, ci2=ci2)
@@ -915,8 +902,7 @@ def compute_cholesky_integrals(mol, mf, basis_coeff, integrals, norb_frozen, cho
             mc.mo_coeff = basis_coeff  # type: ignore
             h1e, enuc = mc.get_h1eff()  # type: ignore
             chol = chol.reshape((-1, nbasis, nbasis))
-            chol = chol[:, mc.ncore: mc.ncore + mc.ncas,
-                        mc.ncore: mc.ncore + mc.ncas]  # type: ignore
+            chol = chol[:, mc.ncore: mc.ncore + mc.ncas, mc.ncore: mc.ncore + mc.ncas]  # type: ignore
     return h1e, chol, nelec, enuc, nbasis, nchol
 
 

--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -146,8 +146,8 @@ def getCollocationMatrices(
     coords = grids.coords
     weights = grids.weights
     ao = mol.eval_gto("GTOval_sph", coords)  ##aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  ##mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  ##mos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights) ** alpha)  ##mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights) ** alpha)  ##mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]
@@ -902,7 +902,7 @@ def compute_cholesky_integrals(mol, mf, basis_coeff, integrals, norb_frozen, cho
             mc.mo_coeff = basis_coeff  # type: ignore
             h1e, enuc = mc.get_h1eff()  # type: ignore
             chol = chol.reshape((-1, nbasis, nbasis))
-            chol = chol[:, mc.ncore: mc.ncore + mc.ncas, mc.ncore: mc.ncore + mc.ncas]  # type: ignore
+            chol = chol[:, mc.ncore : mc.ncore + mc.ncas, mc.ncore : mc.ncore + mc.ncas]  # type: ignore
     return h1e, chol, nelec, enuc, nbasis, nchol
 
 

--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -145,9 +145,9 @@ def getCollocationMatrices(
 
     coords = grids.coords
     weights = grids.weights
-    ao = mol.eval_gto("GTOval_sph", coords)  # aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  # mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  # mos on coords
+    ao = mol.eval_gto("GTOval_sph", coords)  #aos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)** alpha)  #mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)** alpha)  #mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]
@@ -221,7 +221,7 @@ def solveLS_twoSided(T, X1, X2):
     E = jnp.einsum("Pcd, cdQ->PQ", E, X12).T
     V = scipy.linalg.cho_solve((L, True), E)
 
-    #symmetrize it
+    ##symmetrize it
     V = 0.5 * (V + V.T)
 
     return V
@@ -328,7 +328,7 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         shls = (i, i + 1, 0, mol.nbas, i, i + 1, 0, mol.nbas)
         buf = mol.intor("int2e_sph", shls_slice=shls)
         di, dk, dj, dl = buf.shape
-        diag[ndiag: ndiag + di * nao] = buf.reshape(di * nao, di * nao).diagonal()
+        diag[ndiag : ndiag + di * nao] = buf.reshape(di * nao, di * nao).diagonal()
         ndiag += di * nao
     nu = np.argmax(diag)
     delta_max = diag[nu]

--- a/ad_afqmc/pyscf_interface.py
+++ b/ad_afqmc/pyscf_interface.py
@@ -101,7 +101,8 @@ def prep_afqmc(
     chol = chol.reshape((chol.shape[0], -1))
 
     # write trial mo coefficients
-    trial_coeffs = write_trial(mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
+    trial_coeffs = write_trial(
+        mol, mf, basis_coeff, nbasis, norb_frozen, tmpdir)
 
     write_dqmc(
         h1e,
@@ -145,9 +146,11 @@ def getCollocationMatrices(
 
     coords = grids.coords
     weights = grids.weights
-    ao = mol.eval_gto("GTOval_sph", coords)  ##aos on coords
-    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights) ** alpha)  ##mos on coords
-    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights) ** alpha)  ##mos on coords
+    ao = mol.eval_gto("GTOval_sph", coords)  # aos on coords
+    X1 = np.einsum("ri,r->ri", (ao @ mo1), abs(weights)
+                   ** alpha)  # mos on coords
+    X2 = np.einsum("ri,r->ri", (ao @ mo2), abs(weights)
+                   ** alpha)  # mos on coords
 
     P = doISDF(X1, X2, thc_eps)
     return X1[P], X2[P]
@@ -216,12 +219,13 @@ def solveLS_twoSided(T, X1, X2):
     X12 = jnp.einsum("Pa,Pb->abP", X1, X2)
     E = jnp.einsum("abP, abcd->Pcd", X12, T).reshape(X1.shape[0], -1)
 
-    E = scipy.linalg.cho_solve((L, True), E).reshape(-1, T.shape[2], T.shape[3])
+    E = scipy.linalg.cho_solve(
+        (L, True), E).reshape(-1, T.shape[2], T.shape[3])
 
     E = jnp.einsum("Pcd, cdQ->PQ", E, X12).T
     V = scipy.linalg.cho_solve((L, True), E)
 
-    ##symmetrize it
+    # symmetrize it
     V = 0.5 * (V + V.T)
 
     return V
@@ -328,7 +332,8 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         shls = (i, i + 1, 0, mol.nbas, i, i + 1, 0, mol.nbas)
         buf = mol.intor("int2e_sph", shls_slice=shls)
         di, dk, dj, dl = buf.shape
-        diag[ndiag : ndiag + di * nao] = buf.reshape(di * nao, di * nao).diagonal()
+        diag[ndiag: ndiag + di *
+             nao] = buf.reshape(di * nao, di * nao).diagonal()
         ndiag += di * nao
     nu = np.argmax(diag)
     delta_max = diag[nu]
@@ -350,7 +355,8 @@ def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
         "int2e_sph", shls_slice=(0, mol.nbas, 0, mol.nbas, sj, sj + 1, sl, sl + 1)
     )
     cj, cl = max(j - dims[sj], 0), max(l - dims[sl], 0)
-    chol_vecs[0] = np.copy(eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
+    chol_vecs[0] = np.copy(
+        eri_col[:, :, cj, cl].reshape(nao * nao)) / delta_max**0.5
 
     nchol = 0
     while abs(delta_max) > max_error:
@@ -638,7 +644,8 @@ def get_excitations(
             Acre[nex], Ades[nex] = Acre.get(nex, []) + [occ_idx_a_rel], Ades.get(
                 nex, []
             ) + [np.nonzero((d0a - dia) < 0)]
-            coeff[nex][-1] *= parity(d0a, np.nonzero((d0a - dia) > 0), Ades[nex][-1])
+            coeff[nex][-1] *= parity(d0a,
+                                     np.nonzero((d0a - dia) > 0), Ades[nex][-1])
 
         elif nex[0] == 0 and nex[1] > 0:
             occ_idx_b_rel = (
@@ -649,7 +656,8 @@ def get_excitations(
             Bcre[nex], Bdes[nex] = Bcre.get(nex, []) + [occ_idx_b_rel], Bdes.get(
                 nex, []
             ) + [np.nonzero((d0b - dib) < 0)]
-            coeff[nex][-1] *= parity(d0b, np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
+            coeff[nex][-1] *= parity(d0b,
+                                     np.nonzero((d0b - dib) > 0), Bdes[nex][-1])
 
     coeff[(0, 0)] = np.asarray(coeff[(0, 0)]).reshape(
         -1,
@@ -685,10 +693,14 @@ def get_excitations(
         if i != 0:
             for j in range(1, max_excitation + 1 - i):
                 if (i, j) in Ades:
-                    Ades[(i, j)] = np.asarray(Ades[(i, j)]).reshape(-1, i) + num_core
-                    Acre[(i, j)] = np.asarray(Acre[(i, j)]).reshape(-1, i) + num_core
-                    Bdes[(i, j)] = np.asarray(Bdes[(i, j)]).reshape(-1, j) + num_core
-                    Bcre[(i, j)] = np.asarray(Bcre[(i, j)]).reshape(-1, j) + num_core
+                    Ades[(i, j)] = np.asarray(
+                        Ades[(i, j)]).reshape(-1, i) + num_core
+                    Acre[(i, j)] = np.asarray(
+                        Acre[(i, j)]).reshape(-1, i) + num_core
+                    Bdes[(i, j)] = np.asarray(
+                        Bdes[(i, j)]).reshape(-1, j) + num_core
+                    Bcre[(i, j)] = np.asarray(
+                        Bcre[(i, j)]).reshape(-1, j) + num_core
                     coeff[(i, j)] = np.asarray(coeff[(i, j)]).reshape(
                         -1,
                     )
@@ -808,7 +820,7 @@ def parity(d0: np.ndarray, cre: Sequence, des: Sequence) -> float:
     D = np.asarray(des).flatten()
     for i in range(C.shape[0]):
         I, A = min(D[i], C[i]), max(D[i], C[i])
-        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1 : A])) % 2)
+        parity *= 1.0 - 2.0 * ((np.sum(d[I + 1: A])) % 2)
         d[C[i]] = 0
         d[D[i]] = 1
     return float(parity)
@@ -845,7 +857,8 @@ def read_pyscf_ccsd(mf_or_cc, tmpdir):
             ci2bb=ci2bb,
         )
     else:
-        ci2 = cc.t2 + np.einsum("ia,jb->ijab", np.array(cc.t1), np.array(cc.t1))
+        ci2 = cc.t2 + np.einsum("ia,jb->ijab",
+                                np.array(cc.t1), np.array(cc.t1))
         ci2 = ci2.transpose(0, 2, 1, 3)
         ci1 = np.array(cc.t1)
         np.savez(tmpdir + "/amplitudes.npz", ci1=ci1, ci2=ci2)
@@ -902,7 +915,8 @@ def compute_cholesky_integrals(mol, mf, basis_coeff, integrals, norb_frozen, cho
             mc.mo_coeff = basis_coeff  # type: ignore
             h1e, enuc = mc.get_h1eff()  # type: ignore
             chol = chol.reshape((-1, nbasis, nbasis))
-            chol = chol[:, mc.ncore : mc.ncore + mc.ncas, mc.ncore : mc.ncore + mc.ncas]  # type: ignore
+            chol = chol[:, mc.ncore: mc.ncore + mc.ncas,
+                        mc.ncore: mc.ncore + mc.ncas]  # type: ignore
     return h1e, chol, nelec, enuc, nbasis, nchol
 
 
@@ -1089,6 +1103,9 @@ def prep_afqmc_multislater(mf, state_dict, max_excitation, ndets, chol_cut=1e-5)
 
     data = np.load("mo_coeff.npz")
     trial_coeffs = data["mo_coeff"]
+
+    trial_coeffs[0] = trial_coeffs[0].T
+    trial_coeffs[1] = trial_coeffs[1].T
 
     if isinstance(mf, (scf.rhf.RHF, scf.rohf.ROHF)):
         trial_coeffs = trial_coeffs[0]  # alpha = beta here

--- a/examples/hchain.msd.py
+++ b/examples/hchain.msd.py
@@ -1,9 +1,6 @@
-import pickle
-
-import numpy as np
 from pyscf import fci, gto, scf
 
-from ad_afqmc import pyscf_interface, run_afqmc, wavefunctions
+from ad_afqmc import pyscf_interface, run_afqmc
 
 r = 1.6  # 2.0
 nH = 6
@@ -18,25 +15,11 @@ ci = fci.FCI(mf)
 e_fci, _ = ci.kernel()
 print("FCI energy: ", e_fci)
 
-trial = wavefunctions.multislater(mol.nao, mol.nelec, max_excitation=6)
 state_dict = pyscf_interface.get_fci_state(ci, ndets=10)
-Acre, Ades, Bcre, Bdes, coeff, ref_det = pyscf_interface.get_excitations(
-    state=state_dict, max_excitation=6, ndets=10
-)  # this function reads the Dice dets.bin file if state is not provided
-wave_data = {
-    "Acre": Acre,
-    "Ades": Ades,
-    "Bcre": Bcre,
-    "Bdes": Bdes,
-    "coeff": coeff,
-    "ref_det": ref_det,
-    "orbital_rotation": np.eye(mol.nao),
-}
-# write wavefunction to disk
-with open("trial.pkl", "wb") as f:
-    pickle.dump([trial, wave_data], f)
 
-pyscf_interface.prep_afqmc(mf)
+pyscf_interface.prep_afqmc_multislater(
+    mf, state_dict, max_excitation=6, ndets=10)
+
 options = {
     "dt": 0.005,
     "n_eql": 5,

--- a/examples/hchain.uhf.msd.py
+++ b/examples/hchain.uhf.msd.py
@@ -1,0 +1,38 @@
+import pickle
+
+import numpy as np
+from pyscf import fci, gto, scf
+
+from ad_afqmc import pyscf_interface, run_afqmc, wavefunctions
+
+r = 1.6  # 2.0
+nH = 7
+atomstring = ""
+for i in range(nH):
+    atomstring += "H 0 0 %g\n" % (i * r)
+mol = gto.M(atom=atomstring, basis="sto-6g", verbose=3, unit="bohr", spin=1)
+mf = scf.UHF(mol)
+mf.kernel()
+
+ci = fci.FCI(mf)
+e_fci, _ = ci.kernel()
+print("FCI energy: ", e_fci)
+
+state_dict = pyscf_interface.get_fci_state(ci, ndets=100)
+
+pyscf_interface.prep_afqmc_multislater(
+    mf, state_dict, max_excitation=6, ndets=100, chol_cut=1.0e-10)
+
+options = {
+    "dt": 0.005,
+    "n_eql": 5,
+    "n_ene_blocks": 1,
+    "n_sr_blocks": 5,
+    "n_blocks": 100,
+    "n_prop_steps": 50,
+    "n_walkers": 50,
+    "seed": 8,
+    "walker_type": "uhf",
+}
+
+run_afqmc.run_afqmc(options, nproc=2)

--- a/examples/hchain.uhf.msd.py
+++ b/examples/hchain.uhf.msd.py
@@ -14,10 +14,10 @@ ci = fci.FCI(mf)
 e_fci, _ = ci.kernel()
 print("FCI energy: ", e_fci)
 
-state_dict = pyscf_interface.get_fci_state(ci, ndets=100)
+state_dict = pyscf_interface.get_fci_state(ci, ndets=10)
 
 pyscf_interface.prep_afqmc_multislater(
-    mf, state_dict, max_excitation=6, ndets=100, chol_cut=1.0e-10)
+    mf, state_dict, max_excitation=6, ndets=10)
 
 options = {
     "dt": 0.005,

--- a/examples/hchain.uhf.msd.py
+++ b/examples/hchain.uhf.msd.py
@@ -1,9 +1,5 @@
-import pickle
-
-import numpy as np
 from pyscf import fci, gto, scf
-
-from ad_afqmc import pyscf_interface, run_afqmc, wavefunctions
+from ad_afqmc import pyscf_interface, run_afqmc
 
 r = 1.6  # 2.0
 nH = 7


### PR DESCRIPTION
Hi,

Adding a suggestion for preparing AFQMC calculations using multislater trials which handles some of the details for the user (in particular, setting up the orbital rotation) by moving them into the pyscf interface. 

I was having an issue (with an earlier version of the code that did not yet have the option for an orbital rotation) where using a multislater trial with only the UHF determinant included (n_det=1) was giving the incorrect initial AFQMC energy unless the walkers were rotated with the orbital rotation relative to the alpha basis (as in AFQMC/UHF calculations).

Included an H-chain example and some minor cleanup.