### PR TITLE
Additional UCISDT/UCISDTQ tests

### DIFF
--- a/tests/helpers/ucisdtx_molecular.py
+++ b/tests/helpers/ucisdtx_molecular.py
@@ -18,11 +18,17 @@ def _run_uhf(mol, *, dm0=None):
 
 
 def _stability_rerun_uhf(mf):
-    mo_i, _, _, _ = mf.stability(return_status=True)
+    stability_result = mf.stability(return_status=True)
+    if len(stability_result) != 4:
+        raise RuntimeError("UHF stability analysis did not return internal stability status.")
+    mo_i = stability_result[0]
     dm0 = mf.make_rdm1(mo_i, mf.mo_occ)
     mf = _run_uhf(mf.mol, dm0=dm0)
 
-    _, _, stable_i, _ = mf.stability(return_status=True)
+    stability_result = mf.stability(return_status=True)
+    if len(stability_result) != 4:
+        raise RuntimeError("UHF stability analysis did not return internal stability status.")
+    stable_i = stability_result[2]
     if not stable_i:
         raise RuntimeError("UHF stability rerun did not converge to an internally stable solution.")
 

--- a/tests/helpers/ucisdtx_molecular.py
+++ b/tests/helpers/ucisdtx_molecular.py
@@ -1,0 +1,124 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from pyscf import scf
+
+from tests.helpers import hamiltonian_noci_overlaps, noci_overlaps
+from trot.ham.chol import HamChol
+
+
+def _run_uhf(mol, *, dm0=None):
+    mf = scf.UHF(mol)
+    mf.max_cycle = 300
+    mf.conv_tol = 1.0e-14
+    mf.kernel(dm0=dm0)
+    if not mf.converged:
+        raise RuntimeError("UHF did not converge for molecular UCISDT/UCISDTQ test.")
+    return mf
+
+
+def _stability_rerun_uhf(mf):
+    mo_i, _, _, _ = mf.stability(return_status=True)
+    dm0 = mf.make_rdm1(mo_i, mf.mo_occ)
+    mf = _run_uhf(mf.mol, dm0=dm0)
+
+    _, _, stable_i, _ = mf.stability(return_status=True)
+    if not stable_i:
+        raise RuntimeError("UHF stability rerun did not converge to an internally stable solution.")
+
+    s2 = mf.spin_square()[0]
+    if abs(s2) < 1.0e-4:
+        raise RuntimeError("UHF stability rerun did not converge to a spin-broken solution.")
+    return mf
+
+
+def build_ccpy_driver(mol, *, cc_method: str, spin_broken_uhf: bool = False):
+    try:
+        from ccpy.drivers.driver import Driver
+    except Exception as exc:  # pragma: no cover - skip path depends on local ccpy build
+        pytest.skip(f"ccpy is not available in this environment: {exc}")
+
+    mf = _run_uhf(mol)
+    if spin_broken_uhf:
+        mf = _stability_rerun_uhf(mf)
+
+    driver = Driver.from_pyscf(mf, nfrozen=0, uhf=True)
+    driver.options["amp_convergence"] = 1.0e-14
+    driver.options["energy_convergence"] = 1.0e-14
+    driver.options["RHF_symmetry"] = False
+    driver.run_cc(method=cc_method)
+    return mf, driver
+
+
+def ham_from_staged(staged):
+    return HamChol(
+        h0=jnp.asarray(staged.ham.h0),
+        h1=jnp.asarray(staged.ham.h1),
+        chol=jnp.asarray(staged.ham.chol),
+        basis=staged.ham.basis,
+    )
+
+
+def reference_and_rotated_walkers(trial_data, seed: int = 82):
+    nup, ndn = trial_data.nocc
+    norb = trial_data.norb
+
+    wa_ref = trial_data.mo_coeff_a[:, :nup]
+    wb_ref = trial_data.mo_coeff_b[:, :ndn]
+
+    rng = np.random.default_rng(seed)
+    rand_a = jnp.asarray(rng.standard_normal((norb, norb)))
+    rand_b = jnp.asarray(rng.standard_normal((norb, norb)))
+
+    wa_rot = (trial_data.mo_coeff_a @ rand_a)[:, :nup]
+    wb_rot = (trial_data.mo_coeff_b @ rand_b)[:, :ndn]
+
+    return [(wa_ref, wb_ref), (wa_rot, wb_rot)]
+
+
+def trial_to_oracle_ci_amps(trial_data, *, order: int):
+    ci_amps = [
+        [np.float64(1.0)],
+        [np.asarray(trial_data.c1a), np.asarray(trial_data.c1b)],
+        [
+            np.asarray(trial_data.c2aa).transpose(0, 2, 1, 3),
+            np.asarray(trial_data.c2ab).transpose(0, 2, 1, 3),
+            np.asarray(trial_data.c2bb).transpose(0, 2, 1, 3),
+        ],
+        [
+            np.asarray(trial_data.c3aaa).transpose(0, 2, 4, 1, 3, 5),
+            np.asarray(trial_data.c3aab).transpose(0, 2, 4, 1, 3, 5),
+            np.asarray(trial_data.c3abb).transpose(0, 2, 4, 1, 3, 5),
+            np.asarray(trial_data.c3bbb).transpose(0, 2, 4, 1, 3, 5),
+        ],
+    ]
+    if order >= 4:
+        ci_amps.append(
+            [
+                np.asarray(trial_data.c4aaaa).transpose(0, 2, 4, 6, 1, 3, 5, 7),
+                np.asarray(trial_data.c4aaab).transpose(0, 2, 4, 6, 1, 3, 5, 7),
+                np.asarray(trial_data.c4aabb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
+                np.asarray(trial_data.c4abbb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
+                np.asarray(trial_data.c4bbbb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
+            ]
+        )
+    return ci_amps
+
+
+def walker_to_oracle_det_mo(mf, trial_data, walker):
+    wa, wb = walker
+    c_a_ao = np.asarray(mf.mo_coeff[0])
+    c_b_ao = np.asarray(mf.mo_coeff[1])
+    c_b = np.asarray(trial_data.mo_coeff_b)
+
+    wa_ao = c_a_ao @ np.asarray(wa)
+    wb_b_basis = c_b.T @ np.asarray(wb)
+    wb_ao = c_b_ao @ wb_b_basis
+    return (wa_ao, wb_ao)
+
+
+def oracle_overlap_energy(mf, ci_amps, det_mo):
+    overlap = noci_overlaps.evaluate(mf, ci_amps, det_mo)
+    h_overlap = hamiltonian_noci_overlaps.evaluate(mf, ci_amps, det_mo)
+    energy = h_overlap / overlap + mf.mol.energy_nuc()
+    return overlap, energy

--- a/tests/test_ucisdt.py
+++ b/tests/test_ucisdt.py
@@ -133,11 +133,22 @@ def _make_ucisdt_trial(
 _ucisdt_meas_ops_fp64 = functools.partial(make_ucisdt_meas_ops, mixed_precision=False, testing=True)
 
 
+def test_balanced_large_trial_exposes_same_spin_triples():
+    trial = _make_ucisdt_trial(jax.random.PRNGKey(19), norb=6, nup=3, ndn=3)
+
+    assert jnp.linalg.norm(trial.c3aaa) > 1e-12
+    assert jnp.linalg.norm(trial.c3aab) > 1e-12
+    assert jnp.linalg.norm(trial.c3abb) > 1e-12
+    assert jnp.linalg.norm(trial.c3bbb) > 1e-12
+
+
 @pytest.mark.parametrize(
     "walker_kind,norb,nup,ndn,n_chol",
     [
         ("restricted", 4, 2, 2, 5),
+        ("restricted", 6, 3, 3, 7),
         ("unrestricted", 4, 2, 1, 5),
+        ("unrestricted", 6, 3, 3, 7),
     ],
 )
 def test_auto_force_bias_matches_manual_ucisdt(walker_kind, norb, nup, ndn, n_chol):
@@ -171,14 +182,16 @@ def test_auto_force_bias_matches_manual_ucisdt(walker_kind, norb, nup, ndn, n_ch
         wi = testing.make_walkers(jax.random.fold_in(k_w, i), sys)
         v_m = fb_manual(wi, ham, ctx_manual, trial)
         v_a = fb_auto(wi, ham, ctx_auto, trial)
-        assert jnp.allclose(v_a, v_m, atol=1e-6), (v_a, v_m)
+        assert jnp.allclose(v_a, v_m, rtol=1e-10, atol=1e-10), (v_a, v_m)
 
 
 @pytest.mark.parametrize(
     "walker_kind,norb,nup,ndn,n_chol",
     [
         ("restricted", 4, 2, 2, 5),
+        ("restricted", 6, 3, 3, 7),
         ("unrestricted", 6, 3, 2, 8),
+        ("unrestricted", 6, 3, 3, 7),
     ],
 )
 def test_auto_energy_matches_manual_ucisdt(walker_kind, norb, nup, ndn, n_chol):
@@ -215,10 +228,45 @@ def test_auto_energy_matches_manual_ucisdt(walker_kind, norb, nup, ndn, n_chol):
         assert jnp.allclose(e_a, e_m, rtol=5e-5, atol=5e-6), (e_a, e_m)
 
 
+@pytest.mark.slow
+def test_auto_energy_matches_manual_ucisdt_larger_asymmetric_case():
+    key = jax.random.PRNGKey(23)
+    key, k_w = jax.random.split(key)
+
+    norb, nup, ndn, n_chol = 7, 4, 3, 9
+    (
+        sys,
+        ham,
+        trial,
+        meas_manual,
+        ctx_manual,
+        meas_auto,
+        ctx_auto,
+    ) = testing.make_common_auto(
+        key,
+        "unrestricted",
+        norb,
+        (nup, ndn),
+        n_chol,
+        make_trial_fn=_make_ucisdt_trial,
+        make_trial_fn_kwargs=dict(norb=norb, nup=nup, ndn=ndn),
+        make_trial_ops_fn=make_ucisdt_trial_ops,
+        make_meas_ops_fn=_ucisdt_meas_ops_fp64,
+    )
+
+    e_manual = meas_manual.require_kernel(k_energy)
+    e_auto = meas_auto.require_kernel(k_energy)
+
+    wi = testing.make_walkers(k_w, sys)
+    e_m = e_manual(wi, ham, ctx_manual, trial)
+    e_a = e_auto(wi, ham, ctx_auto, trial)
+    assert jnp.allclose(e_a, e_m, rtol=5e-5, atol=5e-6), (e_a, e_m)
+
+
 def test_force_bias_equal_when_wr_eq_wu():
     """Restricted and unrestricted force-bias kernels agree when walkers are equal."""
     norb = 6
-    nup, ndn = 2, 2
+    nup, ndn = 3, 3
     n_chol = 8
     walker_kind = "unrestricted"
 
@@ -249,7 +297,7 @@ def test_force_bias_equal_when_wr_eq_wu():
 def test_energy_equal_when_wr_eq_wu():
     """Restricted and unrestricted energy kernels agree when walkers are equal."""
     norb = 6
-    nup, ndn = 2, 2
+    nup, ndn = 3, 3
     n_chol = 8
     walker_kind = "unrestricted"
 
@@ -289,7 +337,9 @@ def test_generalized_walkers_raise():
     "walker_kind,norb,nup,ndn,n_chol",
     [
         ("restricted", 6, 2, 2, 8),
+        ("restricted", 6, 3, 3, 8),
         ("unrestricted", 6, 2, 1, 8),
+        ("unrestricted", 6, 3, 3, 8),
     ],
 )
 def test_low_memory_matches_high_memory_ucisdt(walker_kind, norb, nup, ndn, n_chol):

--- a/tests/test_ucisdt_molecular.py
+++ b/tests/test_ucisdt_molecular.py
@@ -82,8 +82,8 @@ def _run_ucisdt_oracle_consistency(mol, *, spin_broken_uhf: bool = False):
         ov_t = trial_ops.overlap(walker, trial_data)
         e_t = e_manual(walker, ham, ctx, trial_data)
 
-        assert jnp.allclose(ov_t, ov_o, atol=1e-10), (ov_t, ov_o)
-        assert jnp.allclose(e_t, e_o, atol=1e-10), (e_t, e_o)
+        assert jnp.allclose(ov_t, ov_o, rtol=0.0, atol=1e-10), (ov_t, ov_o)
+        assert jnp.allclose(e_t, e_o, rtol=0.0, atol=1e-10), (e_t, e_o)
 
 
 @pytest.mark.integration

--- a/tests/test_ucisdt_molecular.py
+++ b/tests/test_ucisdt_molecular.py
@@ -2,130 +2,36 @@ from trot import config
 
 config.configure_once()
 
-from dataclasses import replace
-
 import jax.numpy as jnp
-import numpy as np
 import pytest
-from pyscf import gto, scf
+from pyscf import gto
 
-from tests.helpers import hamiltonian_noci_overlaps, noci_overlaps
+from tests.helpers.ucisdtx_molecular import (
+    build_ccpy_driver,
+    ham_from_staged,
+    oracle_overlap_energy,
+    reference_and_rotated_walkers,
+    trial_to_oracle_ci_amps,
+    walker_to_oracle_det_mo,
+)
 from trot.core.ops import k_energy, k_force_bias
 from trot.core.system import System
-from trot.ham.chol import HamChol
 from trot.meas.auto import make_auto_meas_ops
 from trot.meas.ucisdt import make_ucisdt_meas_ops
-from trot.meas.ucisdtq import make_ucisdtq_meas_ops
 from trot.staging import stage_from_ccpy
 from trot.trial.ucisdt import make_ucisdt_trial_data, make_ucisdt_trial_ops
-from trot.trial.ucisdtq import make_ucisdtq_trial_data, make_ucisdtq_trial_ops
 
 
-def _require_ccpy_driver():
-    try:
-        from ccpy.drivers.driver import Driver
-    except Exception as exc:  # pragma: no cover - skip path depends on local ccpy build
-        pytest.skip(f"ccpy is not available in this environment: {exc}")
-    return Driver
-
-
-def _build_ccpy_driver(mol, *, cc_method: str):
-    Driver = _require_ccpy_driver()
-
-    mf = scf.UHF(mol)
-    mf.max_cycle = 300
-    mf.run(conv_tol=1.0e-12)
-    if not mf.converged:
-        raise RuntimeError("UHF did not converge for molecular UCISDT/UCISDTQ test.")
-
-    driver = Driver.from_pyscf(mf, nfrozen=0, uhf=True)
-    driver.options["amp_convergence"] = 1.0e-12
-    driver.options["energy_convergence"] = 1.0e-12
-    driver.options["RHF_symmetry"] = False
-    driver.run_cc(method=cc_method)
-    return mf, driver
-
-
-def _ham_from_staged(staged):
-    return HamChol(
-        h0=jnp.asarray(staged.ham.h0),
-        h1=jnp.asarray(staged.ham.h1),
-        chol=jnp.asarray(staged.ham.chol),
-        basis=staged.ham.basis,
+def _run_ucisdt_molecular_consistency(mol, *, spin_broken_uhf: bool = False):
+    mf, driver = build_ccpy_driver(
+        mol,
+        cc_method="ccsdt",
+        spin_broken_uhf=spin_broken_uhf,
     )
-
-
-def _reference_and_rotated_walkers(trial_data, seed: int = 82):
-    nup, ndn = trial_data.nocc
-    norb = trial_data.norb
-
-    wa_ref = trial_data.mo_coeff_a[:, :nup]
-    wb_ref = trial_data.mo_coeff_b[:, :ndn]
-
-    rng = np.random.default_rng(seed)
-    rand_a = jnp.asarray(rng.standard_normal((norb, norb)))
-    rand_b = jnp.asarray(rng.standard_normal((norb, norb)))
-
-    wa_rot = (trial_data.mo_coeff_a @ rand_a)[:, :nup]
-    wb_rot = (trial_data.mo_coeff_b @ rand_b)[:, :ndn]
-
-    return [(wa_ref, wb_ref), (wa_rot, wb_rot)]
-
-
-def _trial_to_oracle_ci_amps(trial_data, *, order: int):
-    ci_amps = [
-        [np.float64(1.0)],
-        [np.asarray(trial_data.c1a), np.asarray(trial_data.c1b)],
-        [
-            np.asarray(trial_data.c2aa).transpose(0, 2, 1, 3),
-            np.asarray(trial_data.c2ab).transpose(0, 2, 1, 3),
-            np.asarray(trial_data.c2bb).transpose(0, 2, 1, 3),
-        ],
-        [
-            np.asarray(trial_data.c3aaa).transpose(0, 2, 4, 1, 3, 5),
-            np.asarray(trial_data.c3aab).transpose(0, 2, 4, 1, 3, 5),
-            np.asarray(trial_data.c3abb).transpose(0, 2, 4, 1, 3, 5),
-            np.asarray(trial_data.c3bbb).transpose(0, 2, 4, 1, 3, 5),
-        ],
-    ]
-    if order >= 4:
-        ci_amps.append(
-            [
-                np.asarray(trial_data.c4aaaa).transpose(0, 2, 4, 6, 1, 3, 5, 7),
-                np.asarray(trial_data.c4aaab).transpose(0, 2, 4, 6, 1, 3, 5, 7),
-                np.asarray(trial_data.c4aabb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
-                np.asarray(trial_data.c4abbb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
-                np.asarray(trial_data.c4bbbb).transpose(0, 2, 4, 6, 1, 3, 5, 7),
-            ]
-        )
-    return ci_amps
-
-
-def _walker_to_oracle_det_mo(mf, trial_data, walker):
-    wa, wb = walker
-    c_a_ao = np.asarray(mf.mo_coeff[0])
-    c_b_ao = np.asarray(mf.mo_coeff[1])
-    c_b = np.asarray(trial_data.mo_coeff_b)
-
-    wa_ao = c_a_ao @ np.asarray(wa)
-    wb_b_basis = c_b.T @ np.asarray(wb)
-    wb_ao = c_b_ao @ wb_b_basis
-    return (wa_ao, wb_ao)
-
-
-def _oracle_overlap_energy(mf, ci_amps, det_mo):
-    overlap = noci_overlaps.evaluate(mf, ci_amps, det_mo)
-    h_overlap = hamiltonian_noci_overlaps.evaluate(mf, ci_amps, det_mo)
-    energy = h_overlap / overlap + mf.mol.energy_nuc()
-    return overlap, energy
-
-
-def _run_ucisdt_molecular_consistency(mol):
-    mf, driver = _build_ccpy_driver(mol, cc_method="ccsdt")
     staged = stage_from_ccpy(driver, mf, order=3, chol_cut=1.0e-14, verbose=False)
 
     sys = System(norb=int(staged.ham.norb), nelec=staged.ham.nelec, walker_kind="unrestricted")
-    ham = _ham_from_staged(staged)
+    ham = ham_from_staged(staged)
 
     trial_data = make_ucisdt_trial_data(staged.trial.data, sys)
     trial_ops = make_ucisdt_trial_ops(sys)
@@ -140,7 +46,7 @@ def _run_ucisdt_molecular_consistency(mol):
     e_manual = meas_manual.require_kernel(k_energy)
     e_auto = meas_auto.require_kernel(k_energy)
 
-    for walker in _reference_and_rotated_walkers(trial_data):
+    for walker in reference_and_rotated_walkers(trial_data):
         ovlp = trial_ops.overlap(walker, trial_data)
         assert jnp.isfinite(ovlp)
 
@@ -153,74 +59,26 @@ def _run_ucisdt_molecular_consistency(mol):
         assert jnp.allclose(e_a, e_m, rtol=5e-5, atol=5e-6), (e_a, e_m)
 
 
-def _run_ucisdtq_molecular_consistency(mol):
-    mf, driver = _build_ccpy_driver(mol, cc_method="ccsdt")
-    staged_q = stage_from_ccpy(driver, mf, order=4, chol_cut=1.0e-14, verbose=False)
-    staged_t = stage_from_ccpy(driver, mf, order=3, chol_cut=1.0e-14, verbose=False)
-
-    sys = System(norb=int(staged_q.ham.norb), nelec=staged_q.ham.nelec, walker_kind="unrestricted")
-    ham = _ham_from_staged(staged_q)
-
-    trial_t = make_ucisdt_trial_data(staged_t.trial.data, sys)
-    trial_t_ops = make_ucisdt_trial_ops(sys)
-
-    trial_q = make_ucisdtq_trial_data(staged_q.trial.data, sys)
-    trial_q_ops = make_ucisdtq_trial_ops(sys)
-
-    # This is a reduction test for the UCISDTQ kernels, not a staging test.
-    # A CCSDT input staged with order=4 contains disconnected C4 amplitudes;
-    # here we intentionally remove all CI quadruples so the trial is UCISDT.
-    trial_q0 = replace(
-        trial_q,
-        c4aaaa=jnp.zeros_like(trial_q.c4aaaa),
-        c4aaab=jnp.zeros_like(trial_q.c4aaab),
-        c4aabb=jnp.zeros_like(trial_q.c4aabb),
-        c4abbb=jnp.zeros_like(trial_q.c4abbb),
-        c4bbbb=jnp.zeros_like(trial_q.c4bbbb),
+def _run_ucisdt_oracle_consistency(mol, *, spin_broken_uhf: bool = False):
+    mf, driver = build_ccpy_driver(
+        mol,
+        cc_method="ccsdt",
+        spin_broken_uhf=spin_broken_uhf,
     )
-
-    meas_t = make_auto_meas_ops(sys, trial_t_ops, eps=1.0e-4)
-    meas_q = make_ucisdtq_meas_ops(sys, trial_q_ops)
-    ctx_t = meas_t.build_meas_ctx(ham, trial_t)
-    ctx_q = meas_q.build_meas_ctx(ham, trial_q0)
-    fb_t = meas_t.require_kernel(k_force_bias)
-    fb_q = meas_q.require_kernel(k_force_bias)
-    e_t = meas_t.require_kernel(k_energy)
-    e_q = meas_q.require_kernel(k_energy)
-
-    for walker in _reference_and_rotated_walkers(trial_q0):
-        ovlp_t = trial_t_ops.overlap(walker, trial_t)
-        ovlp_q = trial_q_ops.overlap(walker, trial_q0)
-        assert jnp.allclose(ovlp_q, ovlp_t, rtol=5e-6, atol=5e-7), (ovlp_q, ovlp_t)
-
-        v_t = fb_t(walker, ham, ctx_t, trial_t)
-        v_q = fb_q(walker, ham, ctx_q, trial_q0)
-        assert jnp.allclose(v_q, v_t, rtol=5e-5, atol=5e-6), (v_q, v_t)
-
-        e_t_val = e_t(walker, ham, ctx_t, trial_t)
-        e_q_val = e_q(walker, ham, ctx_q, trial_q0)
-        assert jnp.allclose(e_q_val, e_t_val, rtol=5e-5, atol=5e-6), (e_q_val, e_t_val)
-
-
-def _run_ucisdt_oracle_consistency(mol):
-    mf, driver = _build_ccpy_driver(mol, cc_method="ccsdt")
     staged = stage_from_ccpy(driver, mf, order=3, chol_cut=1.0e-14, verbose=False)
 
     sys = System(norb=int(staged.ham.norb), nelec=staged.ham.nelec, walker_kind="unrestricted")
-    ham = _ham_from_staged(staged)
+    ham = ham_from_staged(staged)
     trial_data = make_ucisdt_trial_data(staged.trial.data, sys)
     trial_ops = make_ucisdt_trial_ops(sys)
-    e_manual = make_ucisdt_meas_ops(sys, mixed_precision=False, testing=True).require_kernel(
-        k_energy
-    )
-    ctx = make_ucisdt_meas_ops(sys, mixed_precision=False, testing=True).build_meas_ctx(
-        ham, trial_data
-    )
+    meas = make_ucisdt_meas_ops(sys, mixed_precision=False, testing=True)
+    e_manual = meas.require_kernel(k_energy)
+    ctx = meas.build_meas_ctx(ham, trial_data)
 
-    ci_amps = _trial_to_oracle_ci_amps(trial_data, order=3)
-    for walker in _reference_and_rotated_walkers(trial_data):
-        det_mo = _walker_to_oracle_det_mo(mf, trial_data, walker)
-        ov_o, e_o = _oracle_overlap_energy(mf, ci_amps, det_mo)
+    ci_amps = trial_to_oracle_ci_amps(trial_data, order=3)
+    for walker in reference_and_rotated_walkers(trial_data):
+        det_mo = walker_to_oracle_det_mo(mf, trial_data, walker)
+        ov_o, e_o = oracle_overlap_energy(mf, ci_amps, det_mo)
         ov_t = trial_ops.overlap(walker, trial_data)
         e_t = e_manual(walker, ham, ctx, trial_data)
 
@@ -228,87 +86,135 @@ def _run_ucisdt_oracle_consistency(mol):
         assert jnp.allclose(e_t, e_o, atol=1e-10), (e_t, e_o)
 
 
-def _run_ucisdtq_oracle_consistency(mol):
-    mf, driver = _build_ccpy_driver(mol, cc_method="ccsdt")
-    staged = stage_from_ccpy(driver, mf, order=4, chol_cut=1.0e-14, verbose=False)
-
-    sys = System(norb=int(staged.ham.norb), nelec=staged.ham.nelec, walker_kind="unrestricted")
-    ham = _ham_from_staged(staged)
-    trial_data = make_ucisdtq_trial_data(staged.trial.data, sys)
-    trial_ops = make_ucisdtq_trial_ops(sys)
-    meas = make_ucisdtq_meas_ops(sys, trial_ops)
-    ctx = meas.build_meas_ctx(ham, trial_data)
-    e_kernel = meas.require_kernel(k_energy)
-
-    ci_amps = _trial_to_oracle_ci_amps(trial_data, order=4)
-    for walker in _reference_and_rotated_walkers(trial_data):
-        det_mo = _walker_to_oracle_det_mo(mf, trial_data, walker)
-        ov_o, e_o = _oracle_overlap_energy(mf, ci_amps, det_mo)
-        ov_t = trial_ops.overlap(walker, trial_data)
-        e_t = e_kernel(walker, ham, ctx, trial_data)
-
-        assert jnp.allclose(ov_t, ov_o, atol=1e-10), (ov_t, ov_o)
-        # UCISDTQ measurement uses finite differences, so keep relaxed tolerance.
-        assert jnp.allclose(e_t, e_o, rtol=5e-5, atol=1e-5), (e_t, e_o)
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "mol_kwargs,spin_broken_uhf",
+    [
+        (
+            dict(atom="H 0 0 0; F 1.2 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0),
+            False,
+        ),
+        (
+            dict(atom="H 0 0 0; F 1.7 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0),
+            True,
+        ),
+        (
+            dict(
+                atom=(
+                    "O 0.0 0.0 0.0; "
+                    "H 0.0 0.0 2.2; "
+                    "H 0.95 0.13 -0.25; "
+                    "H -0.24 0.91 0.31"
+                ),
+                basis="3-21g",
+                symmetry="c1",
+                verbose=0,
+                charge=1,
+                spin=0,
+            ),
+            True,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; O 0 1.7 0",
+                basis="3-21g",
+                symmetry="c1",
+                verbose=0,
+                charge=1,
+                spin=3,
+            ),
+            False,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; Be 0 1.7 0; He 7.0 0.0 0.0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+            ),
+            False,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; H 0 1.7 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=1,
+            ),
+            False,
+        ),
+    ],
+)
+def test_ucisdt_molecular_ccsdt_consistency(mol_kwargs, spin_broken_uhf):
+    mol = gto.M(**mol_kwargs)
+    _run_ucisdt_molecular_consistency(mol, spin_broken_uhf=spin_broken_uhf)
 
 
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "mol_kwargs",
+    "mol_kwargs,spin_broken_uhf",
     [
-        dict(atom="H 0 0 0; F 1.2 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0),
-        dict(
-            atom="H 0 0 0; H 0 0 1.1; O 0 1.7 0",
-            basis="3-21g",
-            symmetry="c1",
-            verbose=0,
-            charge=1,
-            spin=3,
+        (
+            dict(atom="H 0 0 0; F 1.2 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0),
+            False,
+        ),
+        (
+            dict(atom="H 0 0 0; F 1.7 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0),
+            True,
+        ),
+        (
+            dict(
+                atom=(
+                    "O 0.0 0.0 0.0; "
+                    "H 0.0 0.0 2.2; "
+                    "H 0.95 0.13 -0.25; "
+                    "H -0.24 0.91 0.31"
+                ),
+                basis="3-21g",
+                symmetry="c1",
+                verbose=0,
+                charge=1,
+                spin=0,
+            ),
+            True,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; O 0 1.7 0",
+                basis="3-21g",
+                symmetry="c1",
+                verbose=0,
+                charge=1,
+                spin=3,
+            ),
+            False,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; Be 0 1.7 0; He 7.0 0.0 0.0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+            ),
+            False,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; H 0 1.7 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=1,
+            ),
+            False,
         ),
     ],
 )
-def test_ucisdt_molecular_ccsdt_consistency(mol_kwargs):
+def test_ucisdt_molecular_matches_legacy_oracle(mol_kwargs, spin_broken_uhf):
     mol = gto.M(**mol_kwargs)
-    _run_ucisdt_molecular_consistency(mol)
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-@pytest.mark.parametrize(
-    "mol_kwargs",
-    [
-        dict(
-            atom="H 0 0 0; H 0 0 1.1; H 0 1.7 0",
-            basis="6-31g",
-            symmetry="c1",
-            verbose=0,
-            charge=0,
-            spin=1,
-        ),
-    ],
-)
-def test_ucisdtq_molecular_reduces_to_ucisdt_when_q_zero(mol_kwargs):
-    mol = gto.M(**mol_kwargs)
-    _run_ucisdtq_molecular_consistency(mol)
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-def test_ucisdt_molecular_matches_legacy_oracle():
-    mol = gto.M(atom="H 0 0 0; F 1.2 0.0 0.0", basis="6-31g", symmetry="c1", verbose=0)
-    _run_ucisdt_oracle_consistency(mol)
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-def test_ucisdtq_molecular_matches_legacy_oracle():
-    mol = gto.M(
-        atom="H 0 0 0; H 0 0 1.1; H 0 1.7 0",
-        basis="6-31g",
-        symmetry="c1",
-        verbose=0,
-        charge=0,
-        spin=1,
-    )
-    _run_ucisdtq_oracle_consistency(mol)
+    _run_ucisdt_oracle_consistency(mol, spin_broken_uhf=spin_broken_uhf)

--- a/tests/test_ucisdt_molecular.py
+++ b/tests/test_ucisdt_molecular.py
@@ -102,10 +102,7 @@ def _run_ucisdt_oracle_consistency(mol, *, spin_broken_uhf: bool = False):
         (
             dict(
                 atom=(
-                    "O 0.0 0.0 0.0; "
-                    "H 0.0 0.0 2.2; "
-                    "H 0.95 0.13 -0.25; "
-                    "H -0.24 0.91 0.31"
+                    "O 0.0 0.0 0.0; " "H 0.0 0.0 2.2; " "H 0.95 0.13 -0.25; " "H -0.24 0.91 0.31"
                 ),
                 basis="3-21g",
                 symmetry="c1",
@@ -169,10 +166,7 @@ def test_ucisdt_molecular_ccsdt_consistency(mol_kwargs, spin_broken_uhf):
         (
             dict(
                 atom=(
-                    "O 0.0 0.0 0.0; "
-                    "H 0.0 0.0 2.2; "
-                    "H 0.95 0.13 -0.25; "
-                    "H -0.24 0.91 0.31"
+                    "O 0.0 0.0 0.0; " "H 0.0 0.0 2.2; " "H 0.95 0.13 -0.25; " "H -0.24 0.91 0.31"
                 ),
                 basis="3-21g",
                 symmetry="c1",

--- a/tests/test_ucisdtq_molecular.py
+++ b/tests/test_ucisdtq_molecular.py
@@ -1,0 +1,248 @@
+from trot import config
+
+config.configure_once()
+
+from dataclasses import replace
+
+import jax.numpy as jnp
+import pytest
+from pyscf import gto
+
+from tests.helpers.ucisdtx_molecular import (
+    build_ccpy_driver,
+    ham_from_staged,
+    oracle_overlap_energy,
+    reference_and_rotated_walkers,
+    trial_to_oracle_ci_amps,
+    walker_to_oracle_det_mo,
+)
+from trot.core.ops import k_energy, k_force_bias
+from trot.core.system import System
+from trot.meas.auto import make_auto_meas_ops
+from trot.meas.ucisdtq import make_ucisdtq_meas_ops
+from trot.staging import stage_from_ccpy
+from trot.trial.ucisdt import make_ucisdt_trial_data, make_ucisdt_trial_ops
+from trot.trial.ucisdtq import make_ucisdtq_trial_data, make_ucisdtq_trial_ops
+
+
+def _run_ucisdtq_molecular_consistency(mol):
+    mf, driver = build_ccpy_driver(mol, cc_method="ccsdt")
+    staged_q = stage_from_ccpy(driver, mf, order=4, chol_cut=1.0e-14, verbose=False)
+    staged_t = stage_from_ccpy(driver, mf, order=3, chol_cut=1.0e-14, verbose=False)
+
+    sys = System(norb=int(staged_q.ham.norb), nelec=staged_q.ham.nelec, walker_kind="unrestricted")
+    ham = ham_from_staged(staged_q)
+
+    trial_t = make_ucisdt_trial_data(staged_t.trial.data, sys)
+    trial_t_ops = make_ucisdt_trial_ops(sys)
+
+    trial_q = make_ucisdtq_trial_data(staged_q.trial.data, sys)
+    trial_q_ops = make_ucisdtq_trial_ops(sys)
+
+    # This is a reduction test for the UCISDTQ kernels, not a staging test.
+    # A CCSDT input staged with order=4 contains disconnected C4 amplitudes;
+    # here we intentionally remove all CI quadruples so the trial is UCISDT.
+    trial_q0 = replace(
+        trial_q,
+        c4aaaa=jnp.zeros_like(trial_q.c4aaaa),
+        c4aaab=jnp.zeros_like(trial_q.c4aaab),
+        c4aabb=jnp.zeros_like(trial_q.c4aabb),
+        c4abbb=jnp.zeros_like(trial_q.c4abbb),
+        c4bbbb=jnp.zeros_like(trial_q.c4bbbb),
+    )
+
+    meas_t = make_auto_meas_ops(sys, trial_t_ops, eps=1.0e-4)
+    meas_q = make_ucisdtq_meas_ops(sys, trial_q_ops)
+    ctx_t = meas_t.build_meas_ctx(ham, trial_t)
+    ctx_q = meas_q.build_meas_ctx(ham, trial_q0)
+    fb_t = meas_t.require_kernel(k_force_bias)
+    fb_q = meas_q.require_kernel(k_force_bias)
+    e_t = meas_t.require_kernel(k_energy)
+    e_q = meas_q.require_kernel(k_energy)
+
+    for walker in reference_and_rotated_walkers(trial_q0):
+        ovlp_t = trial_t_ops.overlap(walker, trial_t)
+        ovlp_q = trial_q_ops.overlap(walker, trial_q0)
+        assert jnp.allclose(ovlp_q, ovlp_t, rtol=5e-6, atol=5e-7), (ovlp_q, ovlp_t)
+
+        v_t = fb_t(walker, ham, ctx_t, trial_t)
+        v_q = fb_q(walker, ham, ctx_q, trial_q0)
+        assert jnp.allclose(v_q, v_t, rtol=5e-5, atol=5e-6), (v_q, v_t)
+
+        e_t_val = e_t(walker, ham, ctx_t, trial_t)
+        e_q_val = e_q(walker, ham, ctx_q, trial_q0)
+        assert jnp.allclose(e_q_val, e_t_val, rtol=5e-5, atol=5e-6), (e_q_val, e_t_val)
+
+
+def _run_ucisdtq_oracle_consistency(
+    mol,
+    *,
+    cc_method: str = "ccsdt",
+    order: int = 4,
+    rotated_eq_unrotated: bool = False,
+):
+    mf, driver = build_ccpy_driver(mol, cc_method=cc_method)
+    staged = stage_from_ccpy(driver, mf, order=order, chol_cut=1.0e-14, verbose=False)
+
+    sys = System(norb=int(staged.ham.norb), nelec=staged.ham.nelec, walker_kind="unrestricted")
+    ham = ham_from_staged(staged)
+    trial_data = make_ucisdtq_trial_data(staged.trial.data, sys)
+    trial_ops = make_ucisdtq_trial_ops(sys)
+    meas = make_ucisdtq_meas_ops(sys, trial_ops)
+    ctx = meas.build_meas_ctx(ham, trial_data)
+    e_kernel = meas.require_kernel(k_energy)
+
+    ci_amps = trial_to_oracle_ci_amps(trial_data, order=4)
+    ref_energy = None
+    for iw, walker in enumerate(reference_and_rotated_walkers(trial_data)):
+        det_mo = walker_to_oracle_det_mo(mf, trial_data, walker)
+        ov_o, e_o = oracle_overlap_energy(mf, ci_amps, det_mo)
+        ov_t = trial_ops.overlap(walker, trial_data)
+        e_t = e_kernel(walker, ham, ctx, trial_data)
+
+        assert jnp.allclose(ov_t, ov_o, atol=1e-10), (ov_t, ov_o)
+        # UCISDTQ measurement uses finite differences, so keep relaxed tolerance.
+        assert jnp.allclose(e_t, e_o, rtol=5e-5, atol=1e-5), (e_t, e_o)
+        if iw == 0:
+            ref_energy = e_t
+        elif rotated_eq_unrotated:
+            assert jnp.allclose(e_t, ref_energy, rtol=5e-5, atol=1e-5), (e_t, ref_energy)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "mol_kwargs",
+    [
+        dict(
+            atom="H 0 0 0; H 0 0 1.1; H 0 1.7 0",
+            basis="6-31g",
+            symmetry="c1",
+            verbose=0,
+            charge=0,
+            spin=1,
+        ),
+    ],
+)
+def test_ucisdtq_molecular_reduces_to_ucisdt_when_q_zero(mol_kwargs):
+    mol = gto.M(**mol_kwargs)
+    _run_ucisdtq_molecular_consistency(mol)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "mol_kwargs,cc_method,order,rotated_eq_unrotated",
+    [
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; He 0 1.7 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsdtq",
+            4,
+            True,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; He 0 1.7 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=2,
+            ),
+            "ccsdtq",
+            4,
+            True,
+        ),
+        (
+            dict(
+                atom="H 0 0 0; H 0 0 1.1; Be 0 1.7 0",
+                basis="sto-3g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsdtq",
+            4,
+            False,
+        ),
+        (
+            dict(
+                atom="He 0 0 0; He 0 0 1.1; He 0 1.7 0; He 1.1 0 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsdtq",
+            4,
+            False,
+        ),
+        (
+            dict(
+                atom="He 0 0 0; He 0 0 1.1; He 0 1.7 0; He 1.1 0 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsdt",
+            4,
+            False,
+        ),
+        (
+            dict(
+                atom="He 0 0 0; He 0 0 1.1; He 0 1.7 0; He 1.1 0 0",
+                basis="6-31g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsd",
+            4,
+            False,
+        ),
+        (
+            dict(
+                atom=(
+                    "H 0.00  0.00  0.00; "
+                    "H 1.15  0.07  0.02; "
+                    "H 2.31 -0.05  0.11; "
+                    "H 3.48  0.09 -0.06; "
+                    "H 4.66 -0.08  0.17; "
+                    "H 5.85  0.12 -0.10; "
+                    "H 7.03 -0.04  0.06; "
+                    "H 8.24  0.06 -0.15"
+                ),
+                basis="sto-3g",
+                symmetry="c1",
+                verbose=0,
+                charge=0,
+                spin=0,
+            ),
+            "ccsdtq",
+            4,
+            False,
+        ),
+    ],
+)
+def test_ucisdtq_molecular_matches_legacy_oracle(
+    mol_kwargs, cc_method, order, rotated_eq_unrotated
+):
+    mol = gto.M(**mol_kwargs)
+    _run_ucisdtq_oracle_consistency(
+        mol,
+        cc_method=cc_method,
+        order=order,
+        rotated_eq_unrotated=rotated_eq_unrotated,
+    )

--- a/tests/test_ucisdtq_molecular.py
+++ b/tests/test_ucisdtq_molecular.py
@@ -100,7 +100,7 @@ def _run_ucisdtq_oracle_consistency(
         ov_t = trial_ops.overlap(walker, trial_data)
         e_t = e_kernel(walker, ham, ctx, trial_data)
 
-        assert jnp.allclose(ov_t, ov_o, atol=1e-10), (ov_t, ov_o)
+        assert jnp.allclose(ov_t, ov_o, rtol=0.0, atol=1e-10), (ov_t, ov_o)
         # UCISDTQ measurement uses finite differences, so keep relaxed tolerance.
         assert jnp.allclose(e_t, e_o, rtol=5e-5, atol=1e-5), (e_t, e_o)
         if iw == 0:

--- a/tests/test_ucisdtq_molecular.py
+++ b/tests/test_ucisdtq_molecular.py
@@ -106,6 +106,7 @@ def _run_ucisdtq_oracle_consistency(
         if iw == 0:
             ref_energy = e_t
         elif rotated_eq_unrotated:
+            assert ref_energy is not None
             assert jnp.allclose(e_t, ref_energy, rtol=5e-5, atol=1e-5), (e_t, ref_energy)
 
 


### PR DESCRIPTION
- Add more tests for triples and quadruples trials to cover edge cases
- Some minor edits (tightened threshold in force bias test, bigger orbital space for random amplitude tests, moved molecular test helpers used for T and Q molecular tests into separate file)